### PR TITLE
doc: fixed misspelled WebUI URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This guide provides you steps to deploy a Stable Diffusion WebUI solution in you
 | [examples](./examples) | Example folder for a working directory | 
 
 ## Introduction
-   This project demos how to effectively host the popular AUTOMATIC1111 web interface [Stable-Diffusion-WebUI](https://github.com/AUTOMATIC11111/stable-diffusion-webui).
+   This project demos how to effectively host the popular AUTOMATIC1111 web interface [Stable-Diffusion-WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
    This is for demo purpose, you may need minimum modification according to your needs before put into production. However, it could also be use directly as an internal project.
    
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -15,7 +15,7 @@
 
 
 ## 介绍
-   该项目演示了如何有效地托管流行的 AUTOMATIC1111 Web 界面 [Stable-Diffusion-WebUI](https://github.com/AUTOMATIC11111/stable-diffusion-webui)。
+   该项目演示了如何有效地托管流行的 AUTOMATIC1111 Web 界面 [Stable-Diffusion-WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui)。
    这是为了演示目的，在投入生产之前，您可能需要根据您的需要进行最少的修改。 但是，它也可以直接用作内部项目。
 
 


### PR DESCRIPTION
Summary:
- Corrected typo in [AUTOMATIC1111](https://github.com/AUTOMATIC1111) Stable Diffussion WebUI URL in README.md
- Corrected typo in [AUTOMATIC1111](https://github.com/AUTOMATIC1111) Stable Diffussion WebUI URL in README_cn.md